### PR TITLE
Fix branch name in ReSpec

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         wgPatentURI:  "https://www.w3.org/2004/01/pp-impl/117488/status",
         github:                  {
             repoURL: "https://github.com/w3c/did-rubric/",
-            branch: "master"
+            branch: "main"
         },
         noRecTrack: "true",
         editors: [{


### PR DESCRIPTION
ReSpec configuration needs to be updated due to renaming the master branch in #3


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cihanss/did-rubric/pull/13.html" title="Last updated on Mar 30, 2021, 11:09 AM UTC (6a9b464)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-rubric/13/3ad55c6...cihanss:6a9b464.html" title="Last updated on Mar 30, 2021, 11:09 AM UTC (6a9b464)">Diff</a>