### PR TITLE
Remove local biblio in favor of specref

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,31 +30,6 @@
         // automatically allow term pluralization
         pluralize: true,
 
-        // extend the bibliography entries
-        localBiblio: {
-          "DID-CORE": {
-            title: "DID Core Specification",
-            href: "https://www.w3.org/TR/did-core/",
-            authors: [
-              "Manu Sporny",
-              "Markus Sabadello",
-              "Drummond Reed"
-            ],
-            status: "WD",
-            publisher: "Decentralized Identifier Working Group"
-          },
-          "DID-SPEC-REGISTRIES": {
-            title: "DID Specification Registries",
-            href: "https://w3c.github.io/did-spec-registries/",
-            authors: [
-              "Orie Steele",
-              "Manu Sporny"
-            ],
-            status: "ED",
-            publisher: "Decentralized Identifier Working Group"
-          }
-        },
-
         github: {
             repoURL: "https://github.com/w3c/did-rubric/",
             branch: "main"


### PR DESCRIPTION
I removed the local references from the header; the system should pick the latest version from the specref database.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-rubric/pull/16.html" title="Last updated on Jun 17, 2021, 7:13 AM UTC (b5b4f66)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-rubric/16/0c6f612...b5b4f66.html" title="Last updated on Jun 17, 2021, 7:13 AM UTC (b5b4f66)">Diff</a>