### PR TITLE
Added numbering for criteria

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       // subtitle: "A reproducible method for evaluating DID Methods",
 
       // if you wish the publication date to be other than today, set this
-      publishDate: "2021-06-15",
+      publishDate: "2021-08-26",
       //previousMaturity: "ED",
 
       // automatically allow term pluralization

--- a/index.html
+++ b/index.html
@@ -473,7 +473,7 @@
             Rubric
           </th>
           <td>
-            <a href="https://www.w3.org/TR/did-rubric/">DID Method Rubric v1.0.0</a>      
+            <a href="https://www.w3.org/TR/did-rubric/">DID Method Rubric v1.0.0</a>
           </td>
         </tr>
         <tr>
@@ -613,7 +613,8 @@
         rules.
       </p>
       <section>
-        <h4>Open contribution (participation)</h4>
+        <h4 id="criteria-1">Open contribution (participation)</h4>
+        <a href="#criteria-1">https://www.w3.org/TR/did-rubric#criteria-1</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -791,7 +792,9 @@
       </section> <!-- participation -->
 
       <section>
-        <h4>Transparency</h4>
+        <h4 id="criteria-2">Transparency</h4>
+        <a href="#criteria-2">https://www.w3.org/TR/did-rubric#criteria-2</a>
+
         <p>
         </p>
         <section>
@@ -966,9 +969,8 @@
       </section> <!-- transparency -->
 
       <section>
-        <h4>Breadth of Authority</h4>
-        <p>
-        </p>
+        <h4 id="criteria-3">Breadth of Authority</h4>
+        <a href="#criteria-3">https://www.w3.org/TR/did-rubric#criteria-3</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -1142,9 +1144,8 @@
       </section> <!-- breadth -->
 
       <section>
-        <h4>Public v private economies</h4>
-        <p>
-        </p>
+        <h4 id="criteria-4">Public v private economies</h4>
+        <a href="#criteria-4">https://www.w3.org/TR/did-rubric#criteria-4</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -1323,9 +1324,8 @@
         </section>
       </section> <!-- public v private -->
       <section>
-        <h4>Cost</h4>
-        <p>
-        </p>
+        <h4 id="criteria-5">Cost</h4>
+        <a href="#criteria-5">https://www.w3.org/TR/did-rubric#criteria-5</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -1522,7 +1522,8 @@
         to this DID method?
       </p>
       <section>
-        <h4>Permissioned operation</h4>
+        <h4 id="criteria-6">Permissioned operation</h4>
+        <a href="#criteria-6">https://www.w3.org/TR/did-rubric#criteria-6</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -1665,7 +1666,8 @@
         </section>
       </section> <!-- permissioned operation -->
       <section>
-        <h4>Interoperability</h4>
+        <h4 id="criteria-7">Interoperability</h4>
+        <a href="#criteria-7">https://www.w3.org/TR/did-rubric#criteria-7</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -1810,7 +1812,8 @@
         </section>
       </section> <!-- interop -->
       <section>
-        <h4>Scope of usage</h4>
+        <h4 id="criteria-8">Scope of usage</h4>
+        <a href="#criteria-8">https://www.w3.org/TR/did-rubric#criteria-8</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -1968,7 +1971,8 @@
     <section>
       <h3>Operation</h3>
       <section>
-        <h4>Financial accountability</h4>
+        <h4 id="criteria-9">Financial accountability</h4>
+        <a href="#criteria-9">https://www.w3.org/TR/did-rubric#criteria-9</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2112,9 +2116,8 @@
         </section>
       </section> <!-- financial -->
       <section>
-        <h4>Limited resource resolution</h4>
-        <p>
-        </p>
+        <h4 id="criteria-10">Limited resource resolution</h4>
+        <a href="#criteria-10">https://www.w3.org/TR/did-rubric#criteria-10</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2267,7 +2270,8 @@
       </section> <!-- resource res -->
 
       <section>
-        <h4>Limited resource registration</h4>
+        <h4 id="criteria-11">Limited resource registration</h4>
+                <a href="#criteria-11">https://www.w3.org/TR/did-rubric#criteria-11</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2479,7 +2483,8 @@
         guidance for enforcement criteria.
       </p>
       <section>
-        <h4>Auditability</h4>
+        <h4 id="criteria-12">Auditability</h4>
+                <a href="#criteria-12">https://www.w3.org/TR/did-rubric#criteria-12</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2616,7 +2621,8 @@
         consideration. As the market matures, this subset of questions will improve.
       </p>
       <section>
-        <h4>Active implementations</h4>
+        <h4 id="criteria-13">Active implementations</h4>
+                <a href="#criteria-13">https://www.w3.org/TR/did-rubric#criteria-13</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2627,7 +2633,8 @@
       </section> <!-- active implementations -->
 
       <section>
-        <h4>Market share</h4>
+        <h4 id="criteria-14">Market share</h4>
+          <a href="#criteria-14">https://www.w3.org/TR/did-rubric#criteria-14</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2637,7 +2644,8 @@
       </section> <!-- market share -->
 
       <section>
-        <h4>Platform support</h4>
+        <h4 id="criteria-15">Platform support</h4>
+        <a href="#criteria-15">https://www.w3.org/TR/did-rubric#criteria-15</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2647,7 +2655,8 @@
       </section> <!-- platform support -->
 
       <section>
-        <h4>Language support</h4>
+        <h4 id="criteria-16">Language support</h4>
+                <a href="#criteria-16">https://www.w3.org/TR/did-rubric#criteria-16</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2657,7 +2666,8 @@
       </section> <!-- language support -->
 
       <section>
-        <h4>Rogue risk</h4>
+        <h4 id="criteria-17">Rogue risk</h4>
+                <a href="#criteria-17">https://www.w3.org/TR/did-rubric#criteria-17</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2668,7 +2678,8 @@
       </section> <!-- rogue risk -->
 
       <section>
-        <h4>Forkability</h4>
+        <h4 id="criteria-18">Forkability</h4>
+                <a href="#criteria-18">https://www.w3.org/TR/did-rubric#criteria-18</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2689,7 +2700,8 @@
       </p>
 
       <section>
-        <h4>Acceptance</h4>
+        <h4 id="criteria-19">Acceptance</h4>
+                <a href="#criteria-19">https://www.w3.org/TR/did-rubric#criteria-19</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2699,7 +2711,8 @@
       </section> <!-- acceptance -->
 
       <section>
-        <h4>Users</h4>
+        <h4 id="criteria-20">Users</h4>
+                <a href="#criteria-20">https://www.w3.org/TR/did-rubric#criteria-20</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2709,7 +2722,8 @@
       </section> <!-- users -->
 
       <section>
-        <h4>International adoption</h4>
+        <h4 id="criteria-21">International adoption</h4>
+        <a href="#criteria-21">https://www.w3.org/TR/did-rubric#criteria-21</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2719,7 +2733,8 @@
       </section><!-- international -->
 
       <section>
-        <h4>In which countries?</h4>
+        <h4 id="criteria-22">In which countries?</h4>
+        <a href="#criteria-22">https://www.w3.org/TR/did-rubric#criteria-22</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2729,7 +2744,8 @@
       </section><!-- which countries -->
 
       <section>
-        <h4>Language support</h4>
+        <h4 id="criteria-23">Language support</h4>
+        <a href="#criteria-23">https://www.w3.org/TR/did-rubric#criteria-23</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2747,7 +2763,8 @@
       </p>
 
       <section>
-        <h4>Robust Crypto</h4>
+        <h4 id="criteria-24">Robust Crypto</h4>
+        <a href="#criteria-24">https://www.w3.org/TR/did-rubric#criteria-24</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2816,7 +2833,8 @@
         </section>
       </section>
       <section>
-        <h4>Expert Review</h4>
+        <h4 id="criteria-25">Expert Review</h4>
+        <a href="#criteria-25">https://www.w3.org/TR/did-rubric#criteria-25</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2886,7 +2904,8 @@
         </section>
       </section>
       <section>
-        <h4>Future Proofing</h4>
+        <h4 id="criteria-26">Future Proofing</h4>
+        <a href="#criteria-26">https://www.w3.org/TR/did-rubric#criteria-26</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2955,7 +2974,8 @@
         </section>
       </section>
       <section>
-        <h4>Self Certification</h4>
+        <h4 id="criteria-27">Self Certification</h4>
+        <a href="#criteria-27">https://www.w3.org/TR/did-rubric#criteria-27</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -3027,7 +3047,8 @@
         </section>
       </section>
       <section>
-        <h4>Availability</h4>
+        <h4 id="criteria-28">Availability</h4>
+        <a href="#criteria-28">https://www.w3.org/TR/did-rubric#criteria-28</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -3093,7 +3114,8 @@
         </section>
       </section>
       <section>
-        <h4>Evolution</h4>
+        <h4 id="criteria-29">Evolution</h4>
+        <a href="#criteria-29">https://www.w3.org/TR/did-rubric#criteria-29</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -3167,7 +3189,8 @@
         </section>
       </section>
       <section>
-        <h4>Many Eyes</h4>
+        <h4 id="criteria-30">Many Eyes</h4>
+        <a href="#criteria-30">https://www.w3.org/TR/did-rubric#criteria-30</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -3239,7 +3262,8 @@
         </section>
       </section>
       <section>
-        <h4>Diffuse Control</h4>
+        <h4 id="criteria-31">Diffuse Control</h4>
+        <a href="#criteria-31">https://www.w3.org/TR/did-rubric#criteria-31</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -3313,7 +3337,8 @@
         </section>
       </section>
       <section>
-        <h4>Regulatory Compliance</h4>
+        <h4 id="criteria-32">Regulatory Compliance</h4>
+        <a href="#criteria-32">https://www.w3.org/TR/did-rubric#criteria-32</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -3394,7 +3419,8 @@
       </p>
 
       <section>
-        <h4>Per-DID constraints on visibility</h4>
+        <h4 id="criteria-33">Per-DID constraints on visibility</h4>
+        <a href="#criteria-33">https://www.w3.org/TR/did-rubric#criteria-33</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -3462,7 +3488,8 @@
         </section>
       </section>
       <section>
-        <h4>Cross-DID Leakage</h4>
+        <h4 id="criteria-34">Cross-DID Leakage</h4>
+        <a href="#criteria-34">https://www.w3.org/TR/did-rubric#criteria-34</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -3531,7 +3558,8 @@
         </section>
       </section>
       <section>
-        <h4>Incentives for Multicontext DIDs</h4>
+        <h4 id="criteria-35">Incentives for Multicontext DIDs</h4>
+        <a href="#criteria-35">https://www.w3.org/TR/did-rubric#criteria-35</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -3599,7 +3627,8 @@
         </section>
       </section>
       <section>
-        <h4>Deletion</h4>
+        <h4 id="criteria-36">Deletion</h4>
+        <a href="#criteria-36">https://www.w3.org/TR/did-rubric#criteria-36</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -3665,7 +3694,8 @@
         </section>
       </section>
       <section>
-        <h4>Help With Best Practice</h4>
+        <h4 id="criteria-37">Help With Best Practice</h4>
+        <a href="#criteria-37">https://www.w3.org/TR/did-rubric#criteria-37</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -3757,7 +3787,7 @@
     </p>
   </section> <!-- conclusion -->
 
-  
+
   <section class="appendix">
     <h2>Terminology</h2>
     <dl>

--- a/index.html
+++ b/index.html
@@ -465,7 +465,7 @@
             Report URL
           </th>
           <td>
-            <a href="https://www.w3.org/TR/did-rubric/"></a>https://www.w3.org/TR/did-rubric/
+            TBD
           </td>
         </tr>
         <tr>
@@ -473,7 +473,7 @@
             Rubric
           </th>
           <td>
-            A Rubric for Decentralization of DID Methods v0.0.1
+            <a href="https://www.w3.org/TR/did-rubric/">DID Method Rubric v1.0.0</a>      
           </td>
         </tr>
         <tr>
@@ -481,7 +481,7 @@
             Rubric URL
           </th>
           <td>
-            TBD
+            <a href="https://www.w3.org/TR/did-rubric/">https://www.w3.org/TR/did-rubric/</a>
           </td>
         </tr>
       </table>

--- a/index.html
+++ b/index.html
@@ -604,8 +604,8 @@
     </section> <!-- evaluation report header -->
     <section>
       <h3>Criteria and Criterion</h3>
-      <p>The term "Criteria" is often informally treated as both a
-        singular and a plural noun. In the singular, we say both "The most
+      <p>The term "criteria" is often treated as both a
+        singular and a plural noun. In the singular, we say "The most
         important criteria is the buyer's age". This singular use of
         criteria has been in use for over half a century <a
           href="https://www.merriam-webster.com/dictionary/criterion#usage-1">https://www.merriam-webster.com/dictionary/criterion#usage-1</a>
@@ -618,13 +618,13 @@
         sentence in the previous paragraph <em>should</em> be "Select one
         criterion from the list of criteria." </p>
       <p>As editors of a Note published by the World Wide Web Consortium,
-        we are torn. We would prefer to use the more
+        we are torn. We would prefer to use 
         rigorous grammar and be consistent in doing so. At the same time,
-        we find attempts to enforce the formal rule often leads to people
-        using the inverse, such as "Select a criteria from the list of
+        we find attempts to enforce the formal rule sometimes leads people
+        to using the inverse, such as "Select a criteria from the list of
         criterion." This is the exact opposite of our desired outcome.</p>
       <p>In our own work with implementers and developers of the DID
-        Method specification, we have found that the singular "criteria" is
+        Core specification, we have found that the singular "criteria" is
         readily accepted and understood and leads to no confusion when
         used, even alongside plural usage. Since the DID Method Rubric
         is, at its core, a set of criteria with ample reason to refer to,

--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
       <p>
         A rubric is a tool used in academia to communicate expectations and evaluate
         performance. It consists of a set of criteria to be evaluated, possible
-        responses for each criterion, and a scoring guide explaining both how to
+        responses for each criteria, and a scoring guide explaining both how to
         choose and interpret each response. The act of evaluating a rubric, which we
         call an Evaluation, provides basis for self-evaluation, procurement decisions,
         or even marketing points. Written records of
@@ -196,7 +196,7 @@
         Where a given Method offers variability, such as multiple networks for the
         same Method, then evaluate each variant. For example, did:ethr supports
         Ethereum mainnet, multiple testnets and permissioned EVM-compliant networks
-        such as Quorum. To apply a criterion to did:ethr, you will evaluate it against
+        such as Quorum. To apply a criteria to did:ethr, you will evaluate it against
         all the variations that matter <em>to you</em>. Each variation should get its
         own <a>Evaluation</a>. This applies to Level 2 Networks that can operate on
         multiple Level 1 Networks as well as DID Methods that directly offer support
@@ -602,8 +602,40 @@
         always be colored by the particular perspective of the <a>Evaluator</a>.
       </p>
     </section> <!-- evaluation report header -->
+    <section>
+      <h3>Criteria and Criterion</h3>
+      <p>The term "Criteria" is often informally treated as both a
+        singular and a plural noun. In the singular, we say both "The most
+        important criteria is the buyer's age". This singular use of
+        criteria has been in use for over half a century <a
+          href="https://www.merriam-webster.com/dictionary/criterion#usage-1">https://www.merriam-webster.com/dictionary/criterion#usage-1</a>
+        In the plural we say "That proposal doesn't meet all of the
+        criteria." Sometimes people use both in the same sentence: "Select
+        one criteria from the list of criteria."
+      </p>
+      <p>However, for formal use, "criteria" is more broadly accepted as
+        plural while "criterion" is singular. By this style rule, the last
+        sentence in the previous paragraph <em>should</em> be "Select one
+        criterion from the list of criteria." </p>
+      <p>As editors of a Note published by the World Wide Web Consortium,
+        we are torn. We would prefer to use the more
+        rigorous grammar and be consistent in doing so. At the same time,
+        we find attempts to enforce the formal rule often leads to people
+        using the inverse, such as "Select a criteria from the list of
+        criterion." This is the exact opposite of our desired outcome.</p>
+      <p>In our own work with implementers and developers of the DID
+        Method specification, we have found that the singular "criteria" is
+        readily accepted and understood and leads to no confusion when
+        used, even alongside plural usage. Since the DID Method Rubric
+        is, at its core, a set of criteria with ample reason to refer to,
+        for example, "Criteria #23", we find the combined singular and
+        plural use is cleaner (just stick with "criteria"), less 
+        confusing, and more aligned with common usage among our audience.</p>
+      <p>As such, throughout the DID Method Rubric, we use the term
+        "criteria" to refer to both singular instances of
+        criteria and plural sets of criteria.</p>
+    </section> <!-- criteria v criterion -->
   </section> <!-- introduction -->
-
   <section>
     <h2>The criteria</h2>
     <section>
@@ -2271,7 +2303,7 @@
 
       <section>
         <h4 id="criteria-11">Limited resource registration</h4>
-                <a href="#criteria-11">https://www.w3.org/TR/did-rubric#criteria-11</a>
+        <a href="#criteria-11">https://www.w3.org/TR/did-rubric#criteria-11</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2483,7 +2515,7 @@
       </p>
       <section>
         <h4 id="criteria-12">Auditability</h4>
-                <a href="#criteria-12">https://www.w3.org/TR/did-rubric#criteria-12</a>
+        <a href="#criteria-12">https://www.w3.org/TR/did-rubric#criteria-12</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2620,7 +2652,7 @@
       </p>
       <section>
         <h4 id="criteria-13">Active implementations</h4>
-                <a href="#criteria-13">https://www.w3.org/TR/did-rubric#criteria-13</a>
+        <a href="#criteria-13">https://www.w3.org/TR/did-rubric#criteria-13</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2632,7 +2664,7 @@
 
       <section>
         <h4 id="criteria-14">Market share</h4>
-          <a href="#criteria-14">https://www.w3.org/TR/did-rubric#criteria-14</a>
+        <a href="#criteria-14">https://www.w3.org/TR/did-rubric#criteria-14</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2654,7 +2686,7 @@
 
       <section>
         <h4 id="criteria-16">Language support</h4>
-                <a href="#criteria-16">https://www.w3.org/TR/did-rubric#criteria-16</a>
+        <a href="#criteria-16">https://www.w3.org/TR/did-rubric#criteria-16</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2665,7 +2697,7 @@
 
       <section>
         <h4 id="criteria-17">Rogue risk</h4>
-                <a href="#criteria-17">https://www.w3.org/TR/did-rubric#criteria-17</a>
+        <a href="#criteria-17">https://www.w3.org/TR/did-rubric#criteria-17</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2677,7 +2709,7 @@
 
       <section>
         <h4 id="criteria-18">Forkability</h4>
-                <a href="#criteria-18">https://www.w3.org/TR/did-rubric#criteria-18</a>
+        <a href="#criteria-18">https://www.w3.org/TR/did-rubric#criteria-18</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2698,7 +2730,7 @@
 
       <section>
         <h4 id="criteria-19">Acceptance</h4>
-                <a href="#criteria-19">https://www.w3.org/TR/did-rubric#criteria-19</a>
+        <a href="#criteria-19">https://www.w3.org/TR/did-rubric#criteria-19</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2709,7 +2741,7 @@
 
       <section>
         <h4 id="criteria-20">Users</h4>
-                <a href="#criteria-20">https://www.w3.org/TR/did-rubric#criteria-20</a>
+        <a href="#criteria-20">https://www.w3.org/TR/did-rubric#criteria-20</a>
         <section>
           <h5>Question</h5>
           <p>
@@ -2798,14 +2830,16 @@
             encryption that's relatively easy to crack, with hashing that's not adequately
             collision-resistant, etc. See
             <a href="https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-3/archive/2012-07-10">
-            NIST 800-57 Part 1, section 5.6.1</a>.
+              NIST 800-57 Part 1, section 5.6.1</a>.
           </p>
         </section>
         <section>
           <h5>Examples</h5>
           <table class="simple">
             <tr>
-              <th>Method</th><th>Score</th><th>Notes</th>
+              <th>Method</th>
+              <th>Score</th>
+              <th>Notes</th>
             </tr>
             <tr>
               <td>
@@ -2898,7 +2932,9 @@
           <h5>Examples</h5>
           <table class="simple">
             <tr>
-              <th>Method</th><th>Score</th><th>Notes</th>
+              <th>Method</th>
+              <th>Score</th>
+              <th>Notes</th>
             </tr>
             <tr>
               <td>
@@ -2909,8 +2945,8 @@
               </td>
               <td>
                 The IOTA ecosystem has <a href="https://trinity.iota.org/security/">
-                published security audits by at least three
-                independent experts</a>. Its code is open source. It uses cryptographic
+                  published security audits by at least three
+                  independent experts</a>. Its code is open source. It uses cryptographic
                 primitives that are well known (e.g., the Blake256-2b hash). It has
                 been running in production for years with no reported CVEs.
               </td>
@@ -2970,7 +3006,9 @@
           <h5>Examples</h5>
           <table class="simple">
             <tr>
-              <th>Method</th><th>Score</th><th>Notes</th>
+              <th>Method</th>
+              <th>Score</th>
+              <th>Notes</th>
             </tr>
             <tr>
               <td>
@@ -3050,7 +3088,9 @@
           <h5>Examples</h5>
           <table class="simple">
             <tr>
-              <th>Method</th><th>Score</th><th>Notes</th>
+              <th>Method</th>
+              <th>Score</th>
+              <th>Notes</th>
             </tr>
             <tr>
               <td>
@@ -3135,7 +3175,9 @@
           <h5>Examples</h5>
           <table class="simple">
             <tr>
-              <th>Method</th><th>Score</th><th>Notes</th>
+              <th>Method</th>
+              <th>Score</th>
+              <th>Notes</th>
             </tr>
             <tr>
               <td>
@@ -3160,10 +3202,12 @@
                 <a href="https://sovrin.org/ssi-metrics-dashboards/">
                   node and network health dashboard</a>, by maintaining statistics
                 about the historic behavior of nodes, by having a
-                <a href="https://github.com/sovrin-foundation/sovrin-sip/blob/master/text/5001-node-selection-algorithm/README.md">
+                <a
+                  href="https://github.com/sovrin-foundation/sovrin-sip/blob/master/text/5001-node-selection-algorithm/README.md">
                   publicly vetted node selection algorithm</a> that forces nodes
                 in different geographies and legal jurisdictions, and by having a
-                <a href="https://github.com/sovrin-foundation/sovrin-sip/tree/master/text/5002-sovrin-crisis-management-plan#readme">
+                <a
+                  href="https://github.com/sovrin-foundation/sovrin-sip/tree/master/text/5002-sovrin-crisis-management-plan#readme">
                   written crisis management plan</a> that has been exercised
                 and reviewed by security professionals. However, a determined
                 adversary might be able to reduce network write speed by submitting
@@ -3305,7 +3349,9 @@
           <h5>Examples</h5>
           <table class="simple">
             <tr>
-              <th>Method</th><th>Score</th><th>Notes</th>
+              <th>Method</th>
+              <th>Score</th>
+              <th>Notes</th>
             </tr>
             <tr>
               <td>
@@ -3390,7 +3436,9 @@
           <h5>Examples</h5>
           <table class="simple">
             <tr>
-              <th>Method</th><th>Score</th><th>Notes</th>
+              <th>Method</th>
+              <th>Score</th>
+              <th>Notes</th>
             </tr>
             <tr>
               <td>
@@ -3541,7 +3589,9 @@
           <h5>Examples</h5>
           <table class="simple">
             <tr>
-              <th>Method</th><th>Score</th><th>Notes</th>
+              <th>Method</th>
+              <th>Score</th>
+              <th>Notes</th>
             </tr>
             <tr>
               <td>
@@ -3624,7 +3674,9 @@
           <h5>Examples</h5>
           <table class="simple">
             <tr>
-              <th>Method</th><th>Score</th><th>Notes</th>
+              <th>Method</th>
+              <th>Score</th>
+              <th>Notes</th>
             </tr>
             <tr>
               <td>


### PR DESCRIPTION
Set up with canonical URIs: https://www.w3.org/TR/did-rubric#criteria-XXX


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/LegReq/did-rubric/pull/28.html" title="Last updated on Aug 17, 2021, 5:34 AM UTC (09d6319)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-rubric/28/eb1d8f7...LegReq:09d6319.html" title="Last updated on Aug 17, 2021, 5:34 AM UTC (09d6319)">Diff</a>