### PR TITLE
Add links to external evaluation and conference paper.

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,6 +282,14 @@
           Optionally, a URL for retrieving the report.
         </li>
       </ol>
+      <p>
+        As an example of externally performed evaluations, <a href="https://www.sba-research.org/">SBA
+        Research</a> in collaboration with <a href="https://danubetech.com/">Danube Tech</a> has performed evaluations
+        of seven different DID methods. A <a href="https://docs.google.com/document/d/1jP-76ul0FZ3H8dChqT2hMtlzvL6B3famQbseZQ0AGS8/">
+        draft evaluation report</a> has
+        been shared, and a <a href="https://eprint.iacr.org/2021/1087">conference paper</a> about this evaluation work
+        and insights from it has been published at the BPM 2021 Blockchain Forum.
+      </p>
     </section> <!-- evaluation -->
 
     <section>


### PR DESCRIPTION
Addresses https://github.com/w3c/did-rubric/issues/45.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-rubric/pull/47.html" title="Last updated on Aug 25, 2021, 8:27 PM UTC (b39b54c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-rubric/47/3342ea1...b39b54c.html" title="Last updated on Aug 25, 2021, 8:27 PM UTC (b39b54c)">Diff</a>